### PR TITLE
Фикс проблемы с малыми объемами оперативной памяти

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -12,10 +12,4 @@ else
   sed -i 's/CONFIG_SERVICE_WORKERS=%{::processorcount}/CONFIG_SERVICE_WORKERS=1/g' answer.cfg
   INTERFACE=`ip route | grep default | sed -e "s/^.*dev.//" -e "s/.proto.*//"`
   sed -i 's/CONFIG_NEUTRON_OVS_BRIDGE_IFACES=$/CONFIG_NEUTRON_OVS_BRIDGE_IFACES=br-ex:'"$INTERFACE"'/g' answer.cfg
-  #Give more swap space for install
-  dd if=/dev/zero of=/swapfile bs=1M count=4096
-  mkswap /swapfile 
-  chmod 600 /swapfile
-  swapon /swapfile
-  echo 'Swap successfully allocated'
 fi

--- a/config.sh
+++ b/config.sh
@@ -12,4 +12,10 @@ else
   sed -i 's/CONFIG_SERVICE_WORKERS=%{::processorcount}/CONFIG_SERVICE_WORKERS=1/g' answer.cfg
   INTERFACE=`ip route | grep default | sed -e "s/^.*dev.//" -e "s/.proto.*//"`
   sed -i 's/CONFIG_NEUTRON_OVS_BRIDGE_IFACES=$/CONFIG_NEUTRON_OVS_BRIDGE_IFACES=br-ex:'"$INTERFACE"'/g' answer.cfg
+  #Give more swap space for install
+  dd if=/dev/zero of=/swapfile bs=1M count=4096
+  mkswap /swapfile 
+  chmod 600 /swapfile
+  swapon /swapfile
+  echo 'Swap successfully allocated'
 fi

--- a/prepare.sh
+++ b/prepare.sh
@@ -16,4 +16,15 @@ else
   yum update -y
   yum install -y openstack-packstack
   packstack --gen-answer-file=answer.cfg
+
+  #Give more swap space for install if it needed
+  mem_number=$(free | grep -v 'used' | awk '{sum+=$2} END {print sum}')
+  minimum_required=$(let 12*1024*1024) # get 12 gb in byte (for me it needed)
+  if [[mem_number < minimum_required]]; then
+    dd if=/dev/zero of=/swapfile bs=1M count=`let (mem_number - minimum_required) / 1024`
+    mkswap /swapfile 
+    chmod 600 /swapfile
+    swapon /swapfile
+    echo 'Swap successfully allocated to 12 GB'
+  fi
 fi

--- a/prepare.sh
+++ b/prepare.sh
@@ -3,15 +3,29 @@ if [[ $EUID > 0 ]]; then
   echo "Please run as root/sudo"
   exit 1
 else
+  systemctl stop NetworkManager
+  systemctl disable NetworkManager
+  systemctl stop firewalld
+  systemctl disable firewalld
+  systemctl restart network
+  setenforce 0
+  sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
+  systemctl start ksmtuned
+  systemctl enable ksmtuned
+  yum install -y centos-release-openstack-rocky
+  yum update -y
+  yum install -y openstack-packstack
+  packstack --gen-answer-file=answer.cfg
+  
   #Give more swap space for install if it needed
-  mem_number=$(free | grep -v 'used' | awk '{sum+=$2} END {print sum}')
-  let "minimum_required= 12*1024*1024" # get 12 gb in byte (for me it needed)
-  if [ $mem_number -lt $minimum_required ]; then
-    let "new_space_mb=(minimum_required-$mem_number)/1024"
-    dd if=/dev/zero of=/swapfile bs=1M count=$new_space_mb
-    mkswap /swapfile 
+  mem_number=$(free | grep -v 'used' | awk '{sum+=$2} END {print sum}') #get current Memory size + Swap size in byte
+  let "minimum_required= 12*1024*1024" # get 12 gb in byte (for me it needed) #get minimum required Memory for script
+  if [ $mem_number -lt $minimum_required ]; then # if we need more space
+    let "new_space_mb=(minimum_required-$mem_number)/1024" #calculate how many space
+    dd if=/dev/zero of=/swapfile bs=1M count=$new_space_mb #give space
+    mkswap /swapfile #make new swap
     chmod 600 /swapfile
-    swapon /swapfile
+    swapon /swapfile #connect swap
     echo 'Swap successfully allocated to 12 GB'
   fi
 fi

--- a/prepare.sh
+++ b/prepare.sh
@@ -3,25 +3,12 @@ if [[ $EUID > 0 ]]; then
   echo "Please run as root/sudo"
   exit 1
 else
-  systemctl stop NetworkManager
-  systemctl disable NetworkManager
-  systemctl stop firewalld
-  systemctl disable firewalld
-  systemctl restart network
-  setenforce 0
-  sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
-  systemctl start ksmtuned
-  systemctl enable ksmtuned
-  yum install -y centos-release-openstack-rocky
-  yum update -y
-  yum install -y openstack-packstack
-  packstack --gen-answer-file=answer.cfg
-
   #Give more swap space for install if it needed
   mem_number=$(free | grep -v 'used' | awk '{sum+=$2} END {print sum}')
-  minimum_required=$(let 12*1024*1024) # get 12 gb in byte (for me it needed)
-  if [[mem_number < minimum_required]]; then
-    dd if=/dev/zero of=/swapfile bs=1M count=`let (mem_number - minimum_required) / 1024`
+  let "minimum_required= 12*1024*1024" # get 12 gb in byte (for me it needed)
+  if [ $mem_number -lt $minimum_required ]; then
+    let "new_space_mb=(minimum_required-$mem_number)/1024"
+    dd if=/dev/zero of=/swapfile bs=1M count=$new_space_mb
     mkswap /swapfile 
     chmod 600 /swapfile
     swapon /swapfile


### PR DESCRIPTION
Скрипт `./prepare.sh` во время своей работы по моим подсчетам съедает около 10 Гб оперативы. В моём случае я мог выделить всего 4Гб ОЗУ виртуалке, по дефолту шло еще 4 Гб swap'а.

Я добавил часть скрипта, которая пополняет Swap до общего объема оперативной памяти в 12 Гб, которых мне хватило на успешное выполнение задания.